### PR TITLE
Fixing Disqus under HTTPS by using protocol-relative URL

### DIFF
--- a/templates/rock/include/comments.html
+++ b/templates/rock/include/comments.html
@@ -23,7 +23,7 @@ var duoshuoQuery = {short_name:"{{config.duoshuo_short_name}}"};
       var disqus_shortname = "{{config.disqus_short_name}}"; 
       (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
       })();
   </script>


### PR DESCRIPTION
When Disqus is used under HTTPS, but the script is loaded via HTTP, modern browsers won't display Disqus and will warn about not-protected parts of the page.
Using protocol-relative URL solves this issue.

https://help.disqus.com/customer/portal/articles/542119-can-disqus-be-loaded-via-https-

(Also, universal code should now be used, but that's a separate issue.
https://disqus.com/admin/universalcode/)