### PR TITLE
Planned posts and draft links

### DIFF
--- a/application/controllers/blog.php
+++ b/application/controllers/blog.php
@@ -12,14 +12,14 @@ class Blog extends CI_Controller {
   }
 
 
-  public function load_common_data($with_drafts=false)
+  public function load_common_data($direct_access=false)
   {
     $this->lang->load('blog', $this->blog_config['language']);
     $this->load->library('twig_lib');    
     twig_extend();    
     $this->data['config'] = $this->blog_config;              
-    $this->data['all_categories'] = $this->blog_lib->get_posts_categories($with_drafts); 
-    $this->data['all_tags'] = $this->blog_lib->get_posts_tags($with_drafts);    
+    $this->data['all_categories'] = $this->blog_lib->get_posts_categories($direct_access); 
+    $this->data['all_tags'] = $this->blog_lib->get_posts_tags($direct_access);    
   }
   
 	public function index()
@@ -41,12 +41,6 @@ class Blog extends CI_Controller {
 	$posts = $this->blog_lib->get_posts();
 
 	$planned_posts_keys = array();
-	foreach($posts as $key => $post)
-		if($post['date'] > time())
-			$planned_posts_keys[] = $key;
-	foreach($planned_posts_keys as $key)
-		unset($posts[$key]);
-	
 
     $offset = ($pageno-1)*$posts_per_page;
     $this->data['posts'] = array_slice($posts,$offset,$posts_per_page);

--- a/application/controllers/blog.php
+++ b/application/controllers/blog.php
@@ -38,7 +38,15 @@ class Blog extends CI_Controller {
     
 
 
-    $posts = $this->blog_lib->get_posts();
+	$posts = $this->blog_lib->get_posts();
+
+	$planned_posts_keys = array();
+	foreach($posts as $key => $post)
+		if($post['date'] > time())
+			$planned_posts_keys[] = $key;
+	foreach($planned_posts_keys as $key)
+		unset($posts[$key]);
+	
 
     $offset = ($pageno-1)*$posts_per_page;
     $this->data['posts'] = array_slice($posts,$offset,$posts_per_page);

--- a/application/controllers/blog.php
+++ b/application/controllers/blog.php
@@ -38,9 +38,7 @@ class Blog extends CI_Controller {
     
 
 
-	$posts = $this->blog_lib->get_posts();
-
-	$planned_posts_keys = array();
+    $posts = $this->blog_lib->get_posts();
 
     $offset = ($pageno-1)*$posts_per_page;
     $this->data['posts'] = array_slice($posts,$offset,$posts_per_page);

--- a/application/controllers/blog.php
+++ b/application/controllers/blog.php
@@ -12,14 +12,14 @@ class Blog extends CI_Controller {
   }
 
 
-  public function load_common_data()
+  public function load_common_data($with_drafts=false)
   {
     $this->lang->load('blog', $this->blog_config['language']);
     $this->load->library('twig_lib');    
     twig_extend();    
     $this->data['config'] = $this->blog_config;              
-    $this->data['all_categories'] = $this->blog_lib->get_posts_categories(); 
-    $this->data['all_tags'] = $this->blog_lib->get_posts_tags();    
+    $this->data['all_categories'] = $this->blog_lib->get_posts_categories($with_drafts); 
+    $this->data['all_tags'] = $this->blog_lib->get_posts_tags($with_drafts);    
   }
   
 	public function index()
@@ -90,8 +90,8 @@ class Blog extends CI_Controller {
   {
     $slug=urldecode($slug);
 
-    $this->load_common_data();
-    $post = $this->blog_lib->get_post($slug);
+    $this->load_common_data(true);
+	$post = $this->blog_lib->get_post($slug);
     if($post===False)
     {
       show_404('Page Not Found.');

--- a/application/controllers/blog.php
+++ b/application/controllers/blog.php
@@ -83,7 +83,7 @@ class Blog extends CI_Controller {
     $slug=urldecode($slug);
 
     $this->load_common_data(true);
-	$post = $this->blog_lib->get_post($slug);
+    $post = $this->blog_lib->get_post($slug);
     if($post===False)
     {
       show_404('Page Not Found.');

--- a/application/language/french/blog_lang.php
+++ b/application/language/french/blog_lang.php
@@ -1,6 +1,6 @@
 <?php
 
-$lang['archive'] = "Archive";
+$lang['archive'] = "Archives";
 $lang['link'] = "Liens";
 $lang['aboutme'] = "À propos";
 $lang['myworks'] = "Travail";

--- a/application/libraries/blog_lib.php
+++ b/application/libraries/blog_lib.php
@@ -262,7 +262,7 @@ class blog_lib{
       return array($category,$files);
   }
 
-  private function __get_all_posts($with_drafts=false)
+  private function __get_all_posts($direct_access=false)
   {
     if(isset($this->_all_posts))
 	{
@@ -351,7 +351,16 @@ class blog_lib{
           if(empty($post_title)){
             $post_title = str_replace('.md','',$entry);
 		  }
-		  if(!$with_drafts && strtolower($post_status)!='public'){
+		  if(!$direct_access && strtolower($post_status)!='public'){
+		    continue;
+		  }
+          if(empty($post_date))
+          {
+            $post_date = filemtime($post_file_path);
+          }else{
+            $post_date = strtotime($post_date);
+          }
+		  if(!$direct_access && $post_date>time()){
 		    continue;
 		  }
           foreach($post_tags as $k=>$row)
@@ -367,12 +376,6 @@ class blog_lib{
                 $all_tags[$trimed_tag] = 1;
               }
             }
-          }
-          if(empty($post_date))
-          {
-            $post_date = filemtime($post_file_path);
-          }else{
-            $post_date = strtotime($post_date);
           }
           if(empty($post_author)){
             $post_author = $this->CI->blog_config['author'];
@@ -399,7 +402,7 @@ class blog_lib{
             $post_category = $temp_c;
           }
 
-          if($with_drafts || $post_status=='public'){
+          if($direct_access || $post_status=='public'){
 
             $files[] = array('fname' => $entry,
             'slug'=>$slug,
@@ -444,9 +447,9 @@ class blog_lib{
     return $this->__get_all_posts();
   }
 
-  public function get_posts_tags($with_drafts=false)
+  public function get_posts_tags($direct_access=false)
   {
-    $this->__get_all_posts($with_drafts);
+    $this->__get_all_posts($direct_access);
     return $this->_all_tags;
   }
 
@@ -468,9 +471,9 @@ class blog_lib{
    return $result;
   }
 
-  public function get_posts_categories($with_drafts=false)
+  public function get_posts_categories($direct_access=false)
   {
-    $this->__get_all_posts($with_drafts);
+    $this->__get_all_posts($direct_access);
     return $this->_all_categories;
   }
 

--- a/application/libraries/blog_lib.php
+++ b/application/libraries/blog_lib.php
@@ -208,7 +208,7 @@ class blog_lib{
     $next_post = array();
     $current_post = array();
     $filename .= '.md';
-    $posts = $this->__get_all_posts();
+	$posts = $this->__get_all_posts(true);
     foreach($posts as $key =>$post){
       if(strtolower($post['fname'])==strtolower($filename)){
         if($key>=1)
@@ -262,12 +262,12 @@ class blog_lib{
       return array($category,$files);
   }
 
-  private function __get_all_posts()
+  private function __get_all_posts($with_drafts=false)
   {
     if(isset($this->_all_posts))
-    {
-      return $this->_all_posts;
-    }
+	{
+	   	return $this->_all_posts;
+	}
     $all_tags = array();
     $posts_path = $this->posts_path;
 
@@ -350,11 +350,10 @@ class blog_lib{
 
           if(empty($post_title)){
             $post_title = str_replace('.md','',$entry);
-          }
-
-          if(strtolower($post_status)!='public'){
-            continue;
-          }
+		  }
+		  if(!$with_drafts && strtolower($post_status)!='public'){
+		    continue;
+		  }
           foreach($post_tags as $k=>$row)
           {
             $trimed_tag = trim($row);
@@ -400,7 +399,7 @@ class blog_lib{
             $post_category = $temp_c;
           }
 
-          if($post_status=='public'){
+          if($with_drafts || $post_status=='public'){
 
             $files[] = array('fname' => $entry,
             'slug'=>$slug,
@@ -445,9 +444,9 @@ class blog_lib{
     return $this->__get_all_posts();
   }
 
-  public function get_posts_tags()
+  public function get_posts_tags($with_drafts=false)
   {
-    $this->__get_all_posts();
+    $this->__get_all_posts($with_drafts);
     return $this->_all_tags;
   }
 
@@ -469,9 +468,9 @@ class blog_lib{
    return $result;
   }
 
-  public function get_posts_categories()
+  public function get_posts_categories($with_drafts=false)
   {
-    $this->__get_all_posts();
+    $this->__get_all_posts($with_drafts);
     return $this->_all_categories;
   }
 


### PR DESCRIPTION
Hello,

This pull request provides features from #95 and #96 

It adds a boolean $direct_access in blog_lib. If set to false, it means the post is accessed for a list (tags, index, RSS, archives) so it :  
- Hides "drafts" posts (no change here)  
  (or)
- Hides the posts when their date is superior to server time (allowing post planning : if you set a date in the future, the post will only appear after the date is reached, even if set to public)

If set to true, that means this is a direct access from posts URL, which means the post will be shown, ignoring the "draft" status or the post date. This will allow to share posts before publishing them, in order to have someone proofread them for instance

Suggestion : add a setting to enable/disable draft preview
